### PR TITLE
Fix bug "Error executing command" in "Create x64dbg script with bp at marked address" feature because of redundant "L" in addresses for x64dbg script

### DIFF
--- a/ddr_installer/plugin/ddr_plugin.py
+++ b/ddr_installer/plugin/ddr_plugin.py
@@ -199,6 +199,9 @@ menu_items = OrderedDict([
 ("DDR_Action_DeleteNonRepeatableComments" , { "menu_str":"Delete non-repeatable comments"                   , "hotkey":None            , "submenu":""              , "ah_id":"DeleteNonRepeatableComments", "x64only":False, "hide_in_context":False})
 ])
 
+def hex(x):
+    return '0x%x' % x
+
 def PLUGIN_ENTRY():
     """ Set plugin entry class """
     return ddrPlugin()


### PR DESCRIPTION
Fix bug "Error executing command" in "Create x64dbg script with bp at marked address" feature because of redundant "L" in addresses for x64dbg script.

![Snap 2020-06-23 at 00 46 26](https://user-images.githubusercontent.com/526959/85364666-d80c1080-b54d-11ea-83a1-f57f9060c49e.png)

![Snap 2020-06-23 at 00 46 41](https://user-images.githubusercontent.com/526959/85364679-dcd0c480-b54d-11ea-961e-421c6cc120e9.png)

![Snap 2020-06-23 at 00 46 53](https://user-images.githubusercontent.com/526959/85364687-e1957880-b54d-11ea-81b9-8ffd915d8082.png)

Another way to solve this problem is stripping the "L" character from the addresses in the file ddr_server.py by replacing 2 lines:
```
breakaddr     = json_content['other']['breakaddr']
org_imagebase = json_content['other']['imagebase']
```
with these 2 lines and vice versa for other addresses:
```
breakaddr     = json_content['other']['breakaddr'].strip('L')
org_imagebase = json_content['other']['imagebase'].strip('L')
```
